### PR TITLE
feat: Implement CommunicationLogDao and tests

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,7 +13,7 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="TagDaoTest">
+      <SelectionState runConfigName="CommunicationLogDaoTest">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/app/src/androidTest/java/com/hollowvyn/kneatr/data/local/dao/CommunicationLogDaoTest.kt
+++ b/app/src/androidTest/java/com/hollowvyn/kneatr/data/local/dao/CommunicationLogDaoTest.kt
@@ -1,0 +1,133 @@
+package com.hollowvyn.kneatr.data.local.dao
+
+import com.hollowvyn.kneatr.data.local.entity.CommunicationLogEntity
+import com.hollowvyn.kneatr.data.local.entity.CommunicationType
+import com.hollowvyn.kneatr.data.local.entity.ContactEntity
+import com.hollowvyn.kneatr.di.DatabaseModule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@HiltAndroidTest
+@UninstallModules(DatabaseModule::class)
+class CommunicationLogDaoTest : BaseDaoTest() {
+    private lateinit var communicationLogDao: CommunicationLogDao
+    private lateinit var contactDao: ContactDao
+
+    @Before
+    fun setup() {
+        communicationLogDao = database.communicationLogDao()
+        contactDao = database.contactDao()
+    }
+
+    private val sampleContact =
+        ContactEntity(
+            contactId = 1,
+            name = "Test Contact",
+            phoneNumber = "1234567890",
+            email = "test@example.com",
+        )
+
+    private val sampleLog1 =
+        CommunicationLogEntity(
+            communicationId = 0,
+            type = CommunicationType.PHONE_CALL,
+            date = LocalDate(2024, 1, 1),
+            contactId = 1,
+            notes = "First call",
+        )
+
+    private val sampleLog2 =
+        CommunicationLogEntity(
+            communicationId = 0,
+            type = CommunicationType.EMAIL,
+            date = LocalDate(2024, 1, 2),
+            contactId = 1,
+            notes = "Follow-up email",
+        )
+
+    @Test
+    fun insert_and_getLogsByContactId() =
+        runTest {
+            contactDao.insertContact(sampleContact)
+            communicationLogDao.insertCommunicationLog(sampleLog1)
+            communicationLogDao.insertCommunicationLog(sampleLog2)
+
+            val logs = communicationLogDao.getCommunicationLogsForContact(1).first()
+            assertEquals(2, logs.size)
+            assertTrue(logs.any { it.notes == "First call" })
+            assertTrue(logs.any { it.type == CommunicationType.EMAIL })
+        }
+
+    @Test
+    fun update_communicationLog() =
+        runTest {
+            contactDao.insertContact(sampleContact)
+            communicationLogDao.insertCommunicationLog(sampleLog1)
+
+            val insertedLog = communicationLogDao.getCommunicationLogsForContact(1).first().first()
+            val updatedLog = insertedLog.copy(notes = "Updated notes")
+            communicationLogDao.updateCommunicationLog(updatedLog)
+
+            val logsAfterUpdate = communicationLogDao.getCommunicationLogsForContact(1).first()
+            assertEquals("Updated notes", logsAfterUpdate.first().notes)
+        }
+
+    @Test
+    fun delete_communicationLog() =
+        runTest {
+            contactDao.insertContact(sampleContact)
+            communicationLogDao.insertCommunicationLog(sampleLog1)
+
+            val insertedLog = communicationLogDao.getCommunicationLogsForContact(1).first().first()
+            communicationLogDao.deleteCommunicationLog(insertedLog)
+
+            val logs = communicationLogDao.getCommunicationLogsForContact(1).first()
+            assertTrue(logs.isEmpty())
+        }
+
+    @Test
+    fun deleteAllLogsForContact() =
+        runTest {
+            contactDao.insertContact(sampleContact)
+            communicationLogDao.insertCommunicationLog(sampleLog1)
+            communicationLogDao.insertCommunicationLog(sampleLog2)
+
+            communicationLogDao.deleteCommunicationLogsForContact(1)
+
+            val logs = communicationLogDao.getCommunicationLogsForContact(1).first()
+            assertTrue(logs.isEmpty())
+        }
+
+    @Test
+    fun deleteAllLogs() =
+        runTest {
+            contactDao.insertContact(sampleContact)
+            communicationLogDao.insertCommunicationLog(sampleLog1)
+            communicationLogDao.insertCommunicationLog(sampleLog2)
+
+            communicationLogDao.deleteAllCommunicationLogs()
+
+            val logs = communicationLogDao.getAllCommunicationLogs().first()
+            assertTrue(logs.isEmpty())
+        }
+
+    @Test
+    fun getLogsByDate() =
+        runTest {
+            contactDao.insertContact(sampleContact)
+            communicationLogDao.insertCommunicationLog(sampleLog1)
+            communicationLogDao.insertCommunicationLog(sampleLog2)
+
+            val logsOnJan1 =
+                communicationLogDao.getCommunicationLogsByDate(LocalDate(2024, 1, 1)).first()
+            assertEquals(1, logsOnJan1.size)
+            assertEquals(CommunicationType.PHONE_CALL, logsOnJan1.first().type)
+        }
+}

--- a/app/src/main/java/com/hollowvyn/kneatr/data/local/dao/CommunicationLogDao.kt
+++ b/app/src/main/java/com/hollowvyn/kneatr/data/local/dao/CommunicationLogDao.kt
@@ -1,0 +1,38 @@
+package com.hollowvyn.kneatr.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.hollowvyn.kneatr.data.local.entity.CommunicationLogEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.LocalDate
+
+@Dao
+interface CommunicationLogDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCommunicationLog(communicationLog: CommunicationLogEntity)
+
+    @Query("SELECT * FROM communication_logs WHERE contactId = :contactId")
+    fun getCommunicationLogsForContact(contactId: Int): Flow<List<CommunicationLogEntity>>
+
+    @Delete
+    suspend fun deleteCommunicationLog(communicationLog: CommunicationLogEntity)
+
+    @Query("DELETE FROM communication_logs WHERE contactId = :contactId")
+    suspend fun deleteCommunicationLogsForContact(contactId: Int)
+
+    @Query("DELETE FROM communication_logs")
+    suspend fun deleteAllCommunicationLogs()
+
+    @Query("SELECT * FROM communication_logs")
+    fun getAllCommunicationLogs(): Flow<List<CommunicationLogEntity>>
+
+    @Query("SELECT * FROM communication_logs WHERE date = :date")
+    fun getCommunicationLogsByDate(date: LocalDate): Flow<List<CommunicationLogEntity>>
+
+    @Update
+    suspend fun updateCommunicationLog(log: CommunicationLogEntity)
+}

--- a/app/src/main/java/com/hollowvyn/kneatr/data/local/database/KneatrDatabase.kt
+++ b/app/src/main/java/com/hollowvyn/kneatr/data/local/database/KneatrDatabase.kt
@@ -3,6 +3,7 @@ package com.hollowvyn.kneatr.data.local.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import com.hollowvyn.kneatr.data.local.dao.CommunicationLogDao
 import com.hollowvyn.kneatr.data.local.dao.ContactDao
 import com.hollowvyn.kneatr.data.local.dao.ContactTagCrossRefDao
 import com.hollowvyn.kneatr.data.local.dao.ContactTagDao
@@ -23,7 +24,7 @@ import com.hollowvyn.kneatr.data.local.typeconverter.LocalDateConverters
         ContactTagCrossRef::class,
         CommunicationLogEntity::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = false,
 )
 @TypeConverters(LocalDateConverters::class, CommunicationTypeConverters::class)
@@ -35,4 +36,6 @@ abstract class KneatrDatabase : RoomDatabase() {
     abstract fun tagDao(): ContactTagDao
 
     abstract fun contactTagCrossRefDao(): ContactTagCrossRefDao
+
+    abstract fun communicationLogDao(): CommunicationLogDao
 }

--- a/app/src/main/java/com/hollowvyn/kneatr/di/DatabaseModule.kt
+++ b/app/src/main/java/com/hollowvyn/kneatr/di/DatabaseModule.kt
@@ -2,6 +2,7 @@ package com.hollowvyn.kneatr.di
 
 import android.content.Context
 import androidx.room.Room
+import com.hollowvyn.kneatr.data.local.dao.CommunicationLogDao
 import com.hollowvyn.kneatr.data.local.dao.ContactDao
 import com.hollowvyn.kneatr.data.local.dao.ContactTagCrossRefDao
 import com.hollowvyn.kneatr.data.local.dao.ContactTagDao
@@ -41,4 +42,7 @@ object DatabaseModule {
 
     @Provides
     fun provideContactDao(database: KneatrDatabase): ContactDao = database.contactDao()
+
+    @Provides
+    fun provideCommunicationLogDao(database: KneatrDatabase): CommunicationLogDao = database.communicationLogDao()
 }


### PR DESCRIPTION
This commit introduces the `CommunicationLogDao` for managing communication log entities within the Kneatr database.

Key changes:
- Created `CommunicationLogDao.kt` with methods for inserting, querying, updating, and deleting communication logs.
- Added tests for `CommunicationLogDao` in `CommunicationLogDaoTest.kt` to ensure correct functionality for all DAO operations.
- Updated `KneatrDatabase.kt`:
    - Incremented database version to 5.
    - Added `CommunicationLogDao` to the database abstract class.
- Updated `DatabaseModule.kt` to provide `CommunicationLogDao` via Dagger Hilt.
- Updated `.idea/deploymentTargetSelector.xml` to reflect the current test being run.