### PR TITLE
feat: Add repository layer and DI module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,6 +89,7 @@ dependencies {
     // Testing
     testImplementation(libs.junit)
     testImplementation(libs.androidx.room.testing)
+    testImplementation(libs.kotlinx.coroutines.test)
 
     // UI Testing
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/hollowvyn/kneatr/data/repository/ContactsRepository.kt
+++ b/app/src/main/java/com/hollowvyn/kneatr/data/repository/ContactsRepository.kt
@@ -1,0 +1,81 @@
+package com.hollowvyn.kneatr.data.repository
+
+import com.hollowvyn.kneatr.domain.model.CommunicationLogDto
+import com.hollowvyn.kneatr.domain.model.ContactDto
+import com.hollowvyn.kneatr.domain.model.ContactTagDto
+import com.hollowvyn.kneatr.domain.model.ContactTierDto
+import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.LocalDate
+
+interface ContactsRepository {
+    // Contact CRUD
+    suspend fun insertContact(contact: ContactDto)
+
+    suspend fun insertContacts(contacts: List<ContactDto>)
+
+    suspend fun updateContact(contact: ContactDto)
+
+    fun getAllContacts(): Flow<List<ContactDto>>
+
+    fun getContactsByTierId(tierId: Long): Flow<List<ContactDto>>
+
+    fun searchContactsByNamePhoneOrEmail(query: String): Flow<List<ContactDto>>
+
+    fun getContactById(id: Long): Flow<ContactDto?>
+
+    // Contact Tag CrossRef operations
+    suspend fun addTagToContact(
+        contactId: Long,
+        tagId: Long,
+    )
+
+    suspend fun removeTagFromContact(
+        contactId: Long,
+        tagId: Long,
+    )
+
+    suspend fun removeAllTagsFromContact(contactId: Long)
+
+    // Tags
+    fun getAllTags(): Flow<Set<ContactTagDto>>
+
+    fun getTagsWithContacts(): Flow<List<Pair<ContactTagDto, List<ContactDto>>>>
+
+    fun getTagWithContactsById(id: Long): Flow<List<ContactDto>?>
+
+    suspend fun insertTag(tag: ContactTagDto)
+
+    suspend fun updateTag(tag: ContactTagDto)
+
+    suspend fun deleteTag(tag: ContactTagDto)
+
+    // Tiers
+    suspend fun insertTier(tier: ContactTierDto)
+
+    suspend fun insertTiers(tiers: List<ContactTierDto>)
+
+    suspend fun updateTier(tier: ContactTierDto)
+
+    fun getAllTiers(): Flow<List<ContactTierDto>>
+
+    fun getTierById(id: Long): Flow<ContactTierDto?>
+
+    suspend fun deleteAllTiers()
+
+    // Communication Logs
+    suspend fun insertCommunicationLog(log: CommunicationLogDto)
+
+    fun getCommunicationLogsForContact(contactId: Long): Flow<List<CommunicationLogDto>>
+
+    suspend fun updateCommunicationLog(log: CommunicationLogDto)
+
+    suspend fun deleteCommunicationLog(log: CommunicationLogDto)
+
+    suspend fun deleteCommunicationLogsForContact(contactId: Long)
+
+    suspend fun deleteAllCommunicationLogs()
+
+    fun getAllCommunicationLogs(): Flow<List<CommunicationLogDto>>
+
+    fun getCommunicationLogsByDate(date: LocalDate): Flow<List<CommunicationLogDto>>
+}

--- a/app/src/main/java/com/hollowvyn/kneatr/data/repository/ContactsRepositoryImpl.kt
+++ b/app/src/main/java/com/hollowvyn/kneatr/data/repository/ContactsRepositoryImpl.kt
@@ -1,0 +1,161 @@
+package com.hollowvyn.kneatr.data.repository
+
+import com.hollowvyn.kneatr.data.local.dao.CommunicationLogDao
+import com.hollowvyn.kneatr.data.local.dao.ContactDao
+import com.hollowvyn.kneatr.data.local.dao.ContactTagCrossRefDao
+import com.hollowvyn.kneatr.data.local.dao.ContactTagDao
+import com.hollowvyn.kneatr.data.local.dao.ContactTierDao
+import com.hollowvyn.kneatr.data.local.entity.crossRef.ContactTagCrossRef
+import com.hollowvyn.kneatr.domain.mappers.toEntity
+import com.hollowvyn.kneatr.domain.mappers.toListEntity
+import com.hollowvyn.kneatr.domain.mappers.toListModel
+import com.hollowvyn.kneatr.domain.mappers.toModel
+import com.hollowvyn.kneatr.domain.mappers.toModelSet
+import com.hollowvyn.kneatr.domain.model.CommunicationLogDto
+import com.hollowvyn.kneatr.domain.model.ContactDto
+import com.hollowvyn.kneatr.domain.model.ContactTagDto
+import com.hollowvyn.kneatr.domain.model.ContactTierDto
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.transform
+import kotlinx.datetime.LocalDate
+import javax.inject.Inject
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ContactsRepositoryImpl
+    @Inject
+    constructor(
+        private val contactDao: ContactDao,
+        private val contactTagCrossRefDao: ContactTagCrossRefDao,
+        private val contactTagDao: ContactTagDao,
+        private val contactTierDao: ContactTierDao,
+        private val communicationLogDao: CommunicationLogDao,
+    ) : ContactsRepository {
+        // Contact operations
+        override suspend fun insertContact(contact: ContactDto) =
+            contact.toEntity().let { contactEntity ->
+                contactDao.insertContact(contactEntity)
+            }
+
+        override suspend fun insertContacts(contacts: List<ContactDto>) = contactDao.insertContacts(contacts.toListEntity())
+
+        override suspend fun updateContact(contact: ContactDto) = contact.toEntity().let { contactDao.updateContact(it) }
+
+        override fun getAllContacts(): Flow<List<ContactDto>> =
+            contactDao.getAllContacts().transform { contacts ->
+                contacts.toListModel()
+            }
+
+        override fun getContactsByTierId(tierId: Long): Flow<List<ContactDto>> =
+            contactDao
+                .getContactsByTierId(
+                    tierId,
+                ).transform {
+                    it.toListModel()
+                }
+
+        override fun searchContactsByNamePhoneOrEmail(query: String): Flow<List<ContactDto>> =
+            contactDao.searchContactsByNamePhoneOrEmail(query).transform { it.toListModel() }
+
+        override fun getContactById(id: Long): Flow<ContactDto?> = contactDao.getContactById(id).transform { it?.toModel() }
+
+        // Tag CrossRef operations
+        override suspend fun addTagToContact(
+            contactId: Long,
+            tagId: Long,
+        ) = contactTagCrossRefDao.addTagToContact(ContactTagCrossRef(contactId, tagId))
+
+        override suspend fun removeTagFromContact(
+            contactId: Long,
+            tagId: Long,
+        ) = contactTagCrossRefDao.removeTagFromContact(ContactTagCrossRef(contactId, tagId))
+
+        override suspend fun removeAllTagsFromContact(contactId: Long) =
+            contactTagCrossRefDao.removeAllTagsFromContact(
+                contactId,
+            )
+
+        // Tag operations
+        override fun getAllTags(): Flow<Set<ContactTagDto>> = contactTagDao.getAllTags().transform { it.toModelSet() }
+
+        override fun getTagsWithContacts(): Flow<List<Pair<ContactTagDto, List<ContactDto>>>> =
+            contactTagDao
+                .getAllTags()
+                .flatMapLatest { tags ->
+                    val flowsPerTag: List<Flow<Pair<ContactTagDto, List<ContactDto>>>> =
+                        tags.map { tag ->
+                            contactDao
+                                .getContactsByTagId(tag.tagId)
+                                .map { contacts ->
+                                    tag.toModel() to contacts.map { it.toModel() }
+                                }
+                        }
+                    combine(flowsPerTag) { pairsArray -> pairsArray.toList() }
+                }
+
+        override fun getTagWithContactsById(id: Long): Flow<List<ContactDto>?> =
+            contactDao.getContactsByTagId(id).transform {
+                it.toListModel()
+            }
+
+        override suspend fun insertTag(tag: ContactTagDto) = contactTagDao.insertTag(tag.toEntity())
+
+        override suspend fun updateTag(tag: ContactTagDto) = contactTagDao.updateTag(tag.toEntity())
+
+        override suspend fun deleteTag(tag: ContactTagDto) = contactTagDao.deleteTag(tag.toEntity())
+
+        // Tier operations
+        override suspend fun insertTier(tier: ContactTierDto) = contactTierDao.insertTier(tier.toEntity())
+
+        override suspend fun insertTiers(tiers: List<ContactTierDto>) = contactTierDao.insertTiers(tiers.map { it.toEntity() })
+
+        override suspend fun updateTier(tier: ContactTierDto) = contactTierDao.updateTier(tier.toEntity())
+
+        override fun getAllTiers(): Flow<List<ContactTierDto>> =
+            contactTierDao.getAllTiers().transform { tiers ->
+                tiers.map { it.toModel() }
+            }
+
+        override fun getTierById(id: Long): Flow<ContactTierDto?> =
+            contactTierDao.getTierById(id).transform {
+                it?.toModel()
+            }
+
+        override suspend fun deleteAllTiers() = contactTierDao.deleteAllTiers()
+
+        // Communication Logs operations
+        override suspend fun insertCommunicationLog(log: CommunicationLogDto) = communicationLogDao.insertCommunicationLog(log.toEntity())
+
+        override fun getCommunicationLogsForContact(contactId: Long): Flow<List<CommunicationLogDto>> =
+            communicationLogDao.getCommunicationLogsForContact(contactId).transform { logs ->
+                logs.map { it.toModel() }
+            }
+
+        override suspend fun updateCommunicationLog(log: CommunicationLogDto) =
+            communicationLogDao.updateCommunicationLog(
+                log.toEntity(),
+            )
+
+        override suspend fun deleteCommunicationLog(log: CommunicationLogDto) =
+            communicationLogDao.deleteCommunicationLog(
+                log.toEntity(),
+            )
+
+        override suspend fun deleteCommunicationLogsForContact(contactId: Long) =
+            communicationLogDao.deleteCommunicationLogsForContact(contactId)
+
+        override suspend fun deleteAllCommunicationLogs() = communicationLogDao.deleteAllCommunicationLogs()
+
+        override fun getAllCommunicationLogs(): Flow<List<CommunicationLogDto>> =
+            communicationLogDao.getAllCommunicationLogs().transform { logs ->
+                logs.map { it.toModel() }
+            }
+
+        override fun getCommunicationLogsByDate(date: LocalDate): Flow<List<CommunicationLogDto>> =
+            communicationLogDao.getCommunicationLogsByDate(date).map { logs ->
+                logs.map { it.toModel() }
+            }
+    }

--- a/app/src/main/java/com/hollowvyn/kneatr/di/RepositoryModule.kt
+++ b/app/src/main/java/com/hollowvyn/kneatr/di/RepositoryModule.kt
@@ -1,0 +1,15 @@
+package com.hollowvyn.kneatr.di
+
+import com.hollowvyn.kneatr.data.repository.ContactsRepository
+import com.hollowvyn.kneatr.data.repository.ContactsRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+    @Binds
+    abstract fun bindsContactsRepository(contactsRepository: ContactsRepositoryImpl): ContactsRepository
+}

--- a/app/src/main/java/com/hollowvyn/kneatr/domain/model/ContactDto.kt
+++ b/app/src/main/java/com/hollowvyn/kneatr/domain/model/ContactDto.kt
@@ -23,7 +23,7 @@ data class CommunicationLogDto(
     val id: Long,
     val type: CommunicationType,
     val date: LocalDate,
-    val contactId: Int,
+    val contactId: Long,
     val notes: String? = null,
 )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 agp = "8.11.1"
 kotlin = "2.2.0"
 kotlinSerialization = "2.2.0"
+kotlinxCoroutinesTest = "1.10.2"
 kotlinxSerializationCore = "1.9.0"
 
 # AndroidX Core
@@ -77,6 +78,7 @@ hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-comp
 hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 
 # Serialization
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
 
 # Testing


### PR DESCRIPTION
This commit introduces the `ContactsRepository` interface and its implementation `ContactsRepositoryImpl`. It also adds a Dagger Hilt module (`RepositoryModule`) to provide the repository dependency.

The repository layer handles data operations for contacts, tags, tiers, and communication logs.

Additionally, the `kotlinx-coroutines-test` dependency is added for testing coroutines.

The `contactId` type in `CommunicationLogDto` has been updated from `Int` to `Long`.