### PR TITLE
Refactor: Improve UI for screen states

### DIFF
--- a/app/src/main/java/com/hollowvyn/kneatr/ui/components/screenstates/EmptyScreen.kt
+++ b/app/src/main/java/com/hollowvyn/kneatr/ui/components/screenstates/EmptyScreen.kt
@@ -2,9 +2,10 @@ package com.hollowvyn.kneatr.ui.components.screenstates
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.VolumeOff
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -12,25 +13,27 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun EmptyScreen(modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.Companion.CenterVertically),
-        horizontalAlignment = Alignment.Companion.CenterHorizontally,
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Icon(
-            imageVector = Icons.AutoMirrored.Filled.VolumeOff,
-            contentDescription = null,
-            modifier = Modifier.Companion.size(80.dp),
+            imageVector = Icons.Filled.Refresh,
+            contentDescription = "Retry Icon",
+            modifier = Modifier.size(80.dp),
         )
 
         Text(
-            text = "Empty",
-            style = MaterialTheme.typography.headlineLarge,
+            text = "It's empty here, try again?",
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
         )
 
         Button(

--- a/app/src/main/java/com/hollowvyn/kneatr/ui/components/screenstates/ErrorScreen.kt
+++ b/app/src/main/java/com/hollowvyn/kneatr/ui/components/screenstates/ErrorScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.VolumeOff
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -13,24 +13,26 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun ErrorScreen(modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier,
+        modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Icon(
-            imageVector = Icons.AutoMirrored.Filled.VolumeOff,
+            imageVector = Icons.Filled.Warning,
             contentDescription = null,
             modifier = Modifier.size(80.dp),
         )
         Text(
-            text = "Error",
-            style = MaterialTheme.typography.headlineLarge,
+            text = "Oops! Something went wrong.",
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
         )
         Button(
             onClick = { /* TODO */ },

--- a/app/src/main/java/com/hollowvyn/kneatr/ui/components/screenstates/LoadingScreen.kt
+++ b/app/src/main/java/com/hollowvyn/kneatr/ui/components/screenstates/LoadingScreen.kt
@@ -2,6 +2,7 @@ package com.hollowvyn.kneatr.ui.components.screenstates
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -9,13 +10,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun LoadingScreen(modifier: Modifier = Modifier) {
     Column(
-        modifier = modifier,
+        modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -25,7 +27,8 @@ fun LoadingScreen(modifier: Modifier = Modifier) {
 
         Text(
             text = "Loading",
-            style = MaterialTheme.typography.headlineLarge,
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
         )
     }
 }


### PR DESCRIPTION
This commit enhances the user interface for `ErrorScreen`, `LoadingScreen`, and `EmptyScreen` components.

Key changes include:
- **General:**
    - All screen state components now use `Modifier.fillMaxSize()` to occupy the entire available space.
    - Text alignment is set to `TextAlign.Center` for better readability.
    - Typography is updated to `MaterialTheme.typography.headlineSmall`.
- **ErrorScreen:**
    - Changed the icon from `Icons.AutoMirrored.Filled.VolumeOff` to `Icons.Filled.Warning`.
    - Updated the error message to "Oops! Something went wrong."
- **EmptyScreen:**
    - Changed the icon from `Icons.AutoMirrored.Filled.VolumeOff` to `Icons.Filled.Refresh`.
    - Updated the message to "It's empty here, try again?".
    - Added a content description "Retry Icon" to the icon.
- **LoadingScreen:**
    - No icon change.
    - Text remains "Loading".