### PR TITLE
refactor(contact): Extract `SearchContactsList` composable

### DIFF
--- a/app/src/main/java/com/hollowvyn/kneatr/ui/contact/list/ContactsList.kt
+++ b/app/src/main/java/com/hollowvyn/kneatr/ui/contact/list/ContactsList.kt
@@ -33,6 +33,7 @@ fun ContactsList(
 ) {
     val listState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
+
     val groupIndexes = mutableMapOf<String, Int>()
     var currentIndex = 0
     grouped.forEach {

--- a/app/src/main/java/com/hollowvyn/kneatr/ui/contact/list/ContactsSearchBar.kt
+++ b/app/src/main/java/com/hollowvyn/kneatr/ui/contact/list/ContactsSearchBar.kt
@@ -96,21 +96,39 @@ fun ContactsSearchBar(
         expanded = expanded,
         onExpandedChange = { expanded = it },
     ) {
-        LazyColumn(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .clickable {
-                        expanded = false
-                        focusManager.clearFocus()
-                    },
-        ) {
-            contactsItems(searchedContacts) {
+        SearchContactsList(
+            searchedContacts = searchedContacts,
+            onLayoutClick = {
+                expanded = false
+                focusManager.clearFocus()
+            },
+            onContactClick = {
                 expanded = false
                 focusManager.clearFocus()
                 onQueryChange("")
                 onContactClick(it)
-            }
+            },
+        )
+    }
+}
+
+@Composable
+fun SearchContactsList(
+    searchedContacts: List<Contact>,
+    onLayoutClick: () -> Unit,
+    onContactClick: (Contact) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .clickable {
+                    onLayoutClick()
+                },
+    ) {
+        contactsItems(searchedContacts) {
+            onContactClick(it)
         }
     }
 }


### PR DESCRIPTION
This commit refactors the `ContactsSearchBar` by extracting the `LazyColumn` used for displaying search results into a new, reusable composable named `SearchContactsList`.

This change improves modularity and makes the `ContactsSearchBar` composable cleaner and more focused on its primary role of handling search logic and state. The new `SearchContactsList` now encapsulates the presentation of the searched contacts list.